### PR TITLE
Navigation-based widget opening

### DIFF
--- a/lib/comprehension_measurement.dart
+++ b/lib/comprehension_measurement.dart
@@ -1,1 +1,2 @@
 export 'src/main.dart' show measureComprehension;
+export 'src/comprehensible_page.dart' show AutoComprehensiblePage;

--- a/lib/src/comprehensible_page.dart
+++ b/lib/src/comprehensible_page.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:comprehension_measurement/comprehension_measurement.dart';
 import 'package:flutter/material.dart';
@@ -7,8 +9,14 @@ abstract class AutoComprehensiblePage extends StatefulWidget {
     Key? key,
     this.comprehensionContext,
     required this.surveyId,
+    this.feedbackId,
+    this.introText = 'Was the last page understandable for you?',
+    this.surveyButtonText = 'Yes',
+    this.feedbackButtonText = 'Close',
+    this.questionContext,
     this.tab = false,
     this.didOpenTab,
+    this.probability = 0.5,
   }) : super(key: key);
 
   @protected
@@ -16,8 +24,14 @@ abstract class AutoComprehensiblePage extends StatefulWidget {
 
   final BuildContext? comprehensionContext;
   final int surveyId;
+  final int? feedbackId;
+  final String introText;
+  final String surveyButtonText;
+  final String feedbackButtonText;
+  final Map<String, List<String>>? questionContext;
   final bool tab;
   final Function? didOpenTab;
+  final double probability;
 
   @override
   State<AutoComprehensiblePage> createState() => _AutoComprehensiblePageState();
@@ -48,15 +62,30 @@ class _AutoComprehensiblePageState extends State<AutoComprehensiblePage>
 
   @override
   void didPushNext() {
-    measureComprehension(
-        widget.comprehensionContext ?? context, widget.surveyId);
+    _measureComprehensionWithProbability();
     super.didPushNext();
   }
 
   @override
   void didPop() {
-    measureComprehension(
-        widget.comprehensionContext ?? context, widget.surveyId);
+    _measureComprehensionWithProbability();
     super.didPop();
+  }
+
+  void _measureComprehensionWithProbability() {
+    Random random = Random();
+    double randomDouble = random.nextDouble();
+
+    if (randomDouble <= widget.probability) {
+      measureComprehension(
+        context: widget.comprehensionContext ?? context,
+        surveyId: widget.surveyId,
+        feedbackId: widget.feedbackId,
+        introText: widget.introText,
+        surveyButtonText: widget.surveyButtonText,
+        feedbackButtonText: widget.feedbackButtonText,
+        questionContext: widget.questionContext,
+      );
+    }
   }
 }

--- a/lib/src/comprehensible_page.dart
+++ b/lib/src/comprehensible_page.dart
@@ -1,0 +1,62 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:comprehension_measurement/comprehension_measurement.dart';
+import 'package:flutter/material.dart';
+
+abstract class AutoComprehensiblePage extends StatefulWidget {
+  const AutoComprehensiblePage({
+    Key? key,
+    this.comprehensionContext,
+    required this.surveyId,
+    this.tab = false,
+    this.didOpenTab,
+  }) : super(key: key);
+
+  @protected
+  Widget build(BuildContext context);
+
+  final BuildContext? comprehensionContext;
+  final int surveyId;
+  final bool tab;
+  final Function? didOpenTab;
+
+  @override
+  State<AutoComprehensiblePage> createState() => _AutoComprehensiblePageState();
+}
+
+class _AutoComprehensiblePageState extends State<AutoComprehensiblePage>
+    with AutoRouteAwareStateMixin<AutoComprehensiblePage> {
+  @override
+  Widget build(BuildContext context) {
+    return widget.build(context);
+  }
+
+  @override
+  void didChangeTabRoute(TabPageRoute previousRoute) {
+    if (widget.didOpenTab != null) {
+      widget.didOpenTab!(previousRoute);
+    }
+    super.didChangeTabRoute(previousRoute);
+  }
+
+  @override
+  void didInitTabRoute(TabPageRoute? previousRoute) {
+    if (widget.didOpenTab != null) {
+      widget.didOpenTab!(previousRoute);
+    }
+    super.didInitTabRoute(previousRoute);
+  }
+
+  @override
+  void didPushNext() {
+    measureComprehension(
+        widget.comprehensionContext ?? context, widget.surveyId);
+    super.didPushNext();
+  }
+
+  @override
+  void didPop() {
+    measureComprehension(
+        widget.comprehensionContext ?? context, widget.surveyId);
+    super.didPop();
+  }
+}

--- a/lib/src/comprehension_measurement.dart
+++ b/lib/src/comprehension_measurement.dart
@@ -16,14 +16,14 @@ class ComprehensionMeasurementWidget extends StatelessWidget {
       required this.introText,
       required this.surveyButtonText,
       required this.feedbackButtonText,
-      required this.questionContext})
+      this.questionContext})
       : super(key: key);
 
   final String introText;
   final String surveyButtonText;
   final String feedbackButtonText;
   final PageController controller = PageController();
-  final Map<String, List<String>> questionContext;
+  final Map<String, List<String>>? questionContext;
 
   void continueSurvey() {
     controller.nextPage(

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -8,7 +8,7 @@ Future<void> measureComprehension({
   required int surveyId,
   required String introText,
   required String surveyButtonText,
-  required Map<String, List<String>> questionContext,
+  Map<String, List<String>>? questionContext,
   int? feedbackId,
   String feedbackButtonText = 'Close',
 }) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   provider: ^6.0.3
   supabase: ^0.3.4
   expandable_page_view: ^1.0.14
+  auto_route: ^4.0.1
 
 dev_dependencies:
   flutter_test:
@@ -22,6 +23,7 @@ dev_dependencies:
   flutter_lints: ^2.0.0
   build_runner: ^2.1.11
   json_serializable: ^6.2.0
+  auto_route_generator: ^4.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Closes #8 

The default probability for opening the survey is 50 %.

### TODO
- [ ] Add usage to Readme

### Usage

- Add `navigatorObservers: () => [AutoRouteObserver()],` to `app.dart` in `_appRouter.delegate`
- Extend `AutoComprehensiblePage` instead of `StateWidget` for example in `TermsAndConditionsPage`
- Require `BuildContext comprehensionContext` in constructor of page, pass this context to the super class

**Example:**

```dart
const TermsAndConditionsPage({
    Key? key,
    required BuildContext comprehensionContext,
  }) : super(
          key: key,
          comprehensionContext: comprehensionContext,
          surveyId: 1,
        );
```

- run the build_runner to generate new route constructor
- go the caller of page and add `comprehensionContext`

**Example:**

```dart
onTap: () => context.router
            .push(TermsAndConditionsRoute(comprehensionContext: context)),
```